### PR TITLE
Add DiscourseConnect SSO support

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -9,3 +9,6 @@ DB_CHARSET=utf8mb4
 
 # Declare the concrete5 environment (This makes /application/config/"live".database.php work)
 CONCRETE5_ENV="live"
+
+# Discourse configuration
+DISCOURSE_SECRET='testsecret'

--- a/README.md
+++ b/README.md
@@ -9,3 +9,28 @@ This repo contains the code for all account management aspects of community.conc
 3. Install concrete5, making sure to select the `concrete_cms_community` starting point. Here is an example of installation via the command line.
 
 `concrete/bin/concrete5 c5:install -vvv --db-server=localhost --db-database=concrete5_community --db-username=user --db-password=password --starting-point=concrete_cms_community --admin-email=your@email.com --admin-password=password`
+
+
+## Discourse SSO
+This project includes api endpoints that support Discourse's [DiscourseConnect](https://meta.discourse.org/t/discourseconnect-official-single-sign-on-for-discourse-sso/13045) SSO API.
+
+#### Setup
+1. Set up discourse SSO (Navigate to discourse /admin/site_settings/category/login)
+    1. Use `http://example.com/ccm/api/v1/discourse/connect` as the "discourse connect url"
+    2. Set a good discourse connect secret, this will be the hmac password so make sure it's secure and secret
+    3. Enable "enable discourse connect"
+    4. Enable all auth override options:
+        1. "discourse connect overrides groups"
+        2. "discourse connect overrides bio"
+        3. "auth overrides username"
+        4. "auth overrides name"
+2. Update .env to have the same secret from step 1.2
+
+Now you should be able to log in using SSO in discourse.
+
+#### TODO
+
+- Implement the unused discourse connect settings
+- Pass through admin and moderator groups
+- Pass through any other important groups
+- Wire up all remaining user metadata

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,8 @@
     }
   },
   "require": {
+    "php": "^7.4",
+    "ext-json": "*",
     "composer/installers": "^1.3",
     "concrete5/core": "dev-develop",
     "concrete5/dependency-patches": "^1.4.0",

--- a/public/packages/concrete_cms_community/controller.php
+++ b/public/packages/concrete_cms_community/controller.php
@@ -3,6 +3,7 @@
 namespace Concrete\Package\ConcreteCmsCommunity;
 
 use Concrete\Core\Package\Package;
+use PortlandLabs\Community\ServiceProvider;
 
 class Controller extends Package
 {
@@ -12,7 +13,7 @@ class Controller extends Package
     protected $pkgVersion = '0.80';
     protected $pkgAutoloaderMapCoreExtensions = true;
     protected $pkgAutoloaderRegistries = array(
-        'src' => '\PortlandLabs\ConcreteCmsCommunity'
+        'src' => '\PortlandLabs\Community'
     );
 
     public function getPackageDescription()
@@ -40,6 +41,7 @@ class Controller extends Package
     
     public function on_start()
     {
-        
+        // Register our service providers
+        $this->app->make(ServiceProvider::class)->register();
     }
 }

--- a/public/packages/concrete_cms_community/src/Discourse/Connect/ConnectController.php
+++ b/public/packages/concrete_cms_community/src/Discourse/Connect/ConnectController.php
@@ -1,0 +1,206 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PortlandLabs\Community\Discourse\Connect;
+
+use Concrete\Core\Http\Request;
+use Concrete\Core\Http\ResponseFactory;
+use Concrete\Core\Routing\RedirectResponse;
+use Concrete\Core\User\PostLoginLocation;
+use Concrete\Core\User\User;
+use League\Url\Components\Query;
+use League\Url\Url;
+use PortlandLabs\Community\Discourse\Connect\Exception\ConnectException;
+use PortlandLabs\Community\Discourse\Connect\Exception\InvalidDataException;
+use PortlandLabs\Community\Discourse\Connect\Exception\NotLoggedInException;
+use ProxyManager\Signature\Exception\InvalidSignatureException;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
+use Throwable;
+
+class ConnectController
+{
+    /**
+     * @var ResponseFactory
+     */
+    private $factory;
+
+    /**
+     * @var User
+     */
+    private $loggedInUser;
+
+    /**
+     * @var PostLoginLocation
+     */
+    private $postLogin;
+
+    /**
+     * @var UserTransformer
+     */
+    private UserTransformer $transformer;
+
+    public function __construct(
+        ResponseFactory $factory,
+        User $user,
+        PostLoginLocation $postLogin,
+        UserTransformer $transformer
+    ) {
+        $this->factory = $factory;
+        $this->loggedInUser = $user;
+        $this->postLogin = $postLogin;
+        $this->transformer = $transformer;
+    }
+
+    /**
+     * Handle DiscourseConnect attempts
+     *
+     * @param Request $request
+     *
+     * @return SymfonyResponse Either a json response or a redirect response
+     */
+    public function connect(Request $request): SymfonyResponse
+    {
+        $data = $request->get('sso', '');
+        $signature = $request->get('sig', '');
+        try {
+            return $this->handleConnect($data, $signature);
+        } catch (NotLoggedInException $e) {
+            return $this->handleLoginRedirect($request, $data, $signature);
+        } catch (Throwable $e) {
+            return $this->handleFailure($e);
+        }
+    }
+
+    /**
+     * Parse and validate a given connect request
+     *
+     * @param string $data
+     * @param string $signature
+     *
+     * @return RedirectResponse
+     *
+     * @throws InvalidSignatureException If the signature is invalid
+     * @throws InvalidDataException If the given data is not valid
+     * @throws NotLoggedInException If the current user is not logged in
+     */
+    private function handleConnect(string $data, string $signature): RedirectResponse
+    {
+        // Validate signature, it's important that we do this first because it weeds out the vast
+        // majority of failure edge cases.
+        $this->validateSignature($data, $signature);
+
+        // Check if the current user is logged in
+        if (!$this->loggedInUser->checkLogin()) {
+            throw ConnectException::notLoggedIn();
+        }
+
+        // Decode into a query string and extract relevant info
+        $data = base64_decode($data);
+        $query = with(new Query($data))->toArray();
+
+        $nonce = $query['nonce'] ?? '';
+        $returnUrl = $query['return_sso_url'] ?? '';
+
+        if (!$nonce || !$returnUrl) {
+            throw ConnectException::invalidData();
+        }
+
+        $userData = $this->getUserData();
+        $userData['nonce'] = $nonce;
+
+        // Convert the user data array to a query string
+        $query = new Query($userData);
+        $dataString = base64_encode((string) $query);
+
+        // Generate a new signature
+        $signature = $this->signature($dataString);
+
+        $url = Url::createFromUrl($returnUrl);
+        $url->setQuery(['sso' => $dataString,'sig' => $signature]);
+
+        return $this->factory->redirect($url, 302);
+    }
+
+    /**
+     * Validate the given DiscourseConnect signature
+     *
+     * @param string $data
+     * @param string $signature
+     *
+     * @return void
+     *
+     * @throws InvalidSignatureException If the signature is invalid
+     */
+    private function validateSignature(string $data, string $signature): void
+    {
+        // Compare the two signatures
+        if (!hash_equals($this->signature($data), $signature)) {
+            throw ConnectException::invalidSignature();
+        }
+    }
+
+    private function signature(string $data): string
+    {
+        return hash_hmac('sha256', $data, getenv('DISCOURSE_SECRET'));
+    }
+
+    /**
+     * Output thrown exceptions for a user to be able to debug
+     * This method will never be called unless discourse has a major misconfiguration or a user is messing around
+     * without valid signatures.
+     *
+     * @param Throwable $e
+     * @return JsonResponse
+     */
+    private function handleFailure(Throwable $e): JsonResponse
+    {
+        $code = 500;
+        $result = [
+            'success' => false,
+            'error' => [
+                'code' => 0,
+                'message' => 'Unknown Error',
+            ]
+        ];
+
+        // Handle exceptions that we throw
+        if ($e instanceof ConnectException) {
+            $result['error']['message'] = $e->getMessage();
+            $result['error']['code'] = $e->getCode();
+            $code = $e->getCode();
+        }
+
+        return $this->factory->json($result, $code);
+    }
+
+    /**
+     * Handle redirecting to login if the user is not currently logged in
+     *
+     * This method needs to make sure to set the post login location so that a user properly flows back
+     * to the forums after successfuly logging in.
+     *
+     * @param Request $request
+     * @param string $data
+     * @param string $signature
+     *
+     * @return RedirectResponse|SymfonyResponse
+     */
+    private function handleLoginRedirect(Request $request, string $data, string $signature)
+    {
+        $this->postLogin->setSessionPostLoginUrl($request->getUri());
+        return $this->factory->redirect('/login', 302);
+    }
+
+    /**
+     * Get the datq associated with the logged in user
+     *
+     * @return array
+     */
+    private function getUserData(): array
+    {
+        return $this->transformer->transform($this->loggedInUser);
+    }
+
+}

--- a/public/packages/concrete_cms_community/src/Discourse/Connect/Exception/ConnectException.php
+++ b/public/packages/concrete_cms_community/src/Discourse/Connect/Exception/ConnectException.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace PortlandLabs\Community\Discourse\Connect\Exception;
+
+use RuntimeException;
+
+abstract class ConnectException extends RuntimeException
+{
+
+    public static function notLoggedIn(): NotLoggedInException
+    {
+        return new NotLoggedInException();
+    }
+
+    public static function invalidData(): InvalidDataException
+    {
+        return new InvalidDataException();
+    }
+
+    public static function invalidSignature(): SignatureNotValidException
+    {
+        return new SignatureNotValidException();
+    }
+
+}

--- a/public/packages/concrete_cms_community/src/Discourse/Connect/Exception/InvalidDataException.php
+++ b/public/packages/concrete_cms_community/src/Discourse/Connect/Exception/InvalidDataException.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace PortlandLabs\Community\Discourse\Connect\Exception;
+
+class InvalidDataException extends ConnectException
+{
+
+    public function __construct()
+    {
+        parent::__construct('Invalid data provided.', 400);
+    }
+
+}

--- a/public/packages/concrete_cms_community/src/Discourse/Connect/Exception/NotLoggedInException.php
+++ b/public/packages/concrete_cms_community/src/Discourse/Connect/Exception/NotLoggedInException.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace PortlandLabs\Community\Discourse\Connect\Exception;
+
+class NotLoggedInException extends ConnectException
+{
+
+    public function __construct()
+    {
+        parent::__construct('User is not logged in.', 403);
+    }
+
+}

--- a/public/packages/concrete_cms_community/src/Discourse/Connect/Exception/SignatureNotValidException.php
+++ b/public/packages/concrete_cms_community/src/Discourse/Connect/Exception/SignatureNotValidException.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace PortlandLabs\Community\Discourse\Connect\Exception;
+
+class SignatureNotValidException extends ConnectException
+{
+
+    public function __construct()
+    {
+        parent::__construct('Invalid signature provided.', 400);
+    }
+
+}

--- a/public/packages/concrete_cms_community/src/Discourse/Connect/UserTransformer.php
+++ b/public/packages/concrete_cms_community/src/Discourse/Connect/UserTransformer.php
@@ -1,0 +1,64 @@
+<?php
+declare(strict_types=1);
+
+namespace PortlandLabs\Community\Discourse\Connect;
+
+use Concrete\Core\Url\Resolver\Manager\ResolverManager;
+use Concrete\Core\User\User;
+use League\Fractal\TransformerAbstract;
+
+class UserTransformer extends TransformerAbstract
+{
+
+    /**
+     * @var ResolverManager
+     */
+    private ResolverManager $urls;
+
+    public function __construct(ResolverManager $urls)
+    {
+        $this->urls = $urls;
+    }
+
+    /**
+     * Transform a given user into a DiscourseConnect friendly list of attributes.
+     *
+     * @param User $user
+     *
+     * @return array
+     */
+    public function transform(User $user)
+    {
+        $userInfo = $user->getUserInfoObject();
+        $avatar = $userInfo->getUserAvatar();
+        return [
+            'external_id' => $user->getUserID(),
+            'email' => $userInfo->getUserEmail(),
+            'username' => $user->getUserName(),
+            'name' => collect(
+                [
+                    $userInfo->getAttribute('first_name'),
+                    $userInfo->getAttribute('last_name'),
+                ]
+            )->filter()->implode(' '),
+            'avatar_url' => $this->urls->resolve([$avatar->getPath()]),
+            'avatar_force_update' => 'true',
+            'suppress_welcome_message' => 'true',
+
+            // Not yet used
+            'title' => '',
+            'website' => '',
+            'location' => '',
+            'groups' => '',
+            'remove_groups' => '',
+            'require_activation' => 'false',
+            'locale' => '',
+            'locale_force_update' => 'false',
+            'logout' => 'false',
+            'bio' => '',
+            'admin' => 'false',
+            'moderator' => 'false',
+        ];
+    }
+
+}

--- a/public/packages/concrete_cms_community/src/Discourse/ServiceProvider.php
+++ b/public/packages/concrete_cms_community/src/Discourse/ServiceProvider.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PortlandLabs\Community\Discourse;
+
+use Concrete\Core\Foundation\Service\Provider;
+use Concrete\Core\Routing\Router;
+use PortlandLabs\Community\Discourse\Connect\ConnectController;
+
+class ServiceProvider extends Provider
+{
+
+    public function register()
+    {
+        $router = $this->app->make(Router::class);
+        $router->buildGroup()
+            ->setPrefix('ccm/api/v1/discourse')
+            ->scope('discourse_connect')
+            ->routes(fn(Router $router) => $this->routes($router), 'concrete_cms_community');
+    }
+
+    private function routes(Router $router)
+    {
+        // ccm/api/v1/discourse/connect
+        $router->get('connect', ConnectController::class . '::connect');
+    }
+}

--- a/public/packages/concrete_cms_community/src/ServiceProvider.php
+++ b/public/packages/concrete_cms_community/src/ServiceProvider.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PortlandLabs\Community;
+
+use Concrete\Core\Foundation\Service\Provider;
+use PortlandLabs\Community\Discourse\ServiceProvider as DiscourseProvider;
+
+class ServiceProvider extends Provider
+{
+    protected $providers = [
+        DiscourseProvider::class // Discourse connect SSO
+    ];
+
+    public function register()
+    {
+        foreach ($this->providers as $provider) {
+            $this->app->make($provider)->register();
+        }
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -16,3 +16,8 @@ $list->registerMultiple($aliases);
 // Register an autoloader for those aliases
 $autoloader = new \Concrete\Core\Foundation\AliasClassLoader($list);
 $autoloader->register();
+
+// Register a new autoloader for connect package
+$loader = new \Concrete\Core\Foundation\Psr4ClassLoader();
+$loader->addPrefix('PortlandLabs\Community', __DIR__ . '/../public/packages/concrete_cms_community/src');
+$loader->register();

--- a/tests/packages/concrete_cms_community/Discourse/Connect/ConnectControllerTest.php
+++ b/tests/packages/concrete_cms_community/Discourse/Connect/ConnectControllerTest.php
@@ -1,0 +1,184 @@
+<?php
+
+use Concrete\Core\Http\Request;
+use Concrete\Core\Http\ResponseFactory;
+use Concrete\Core\User\PostLoginLocation;
+use Concrete\Core\User\User;
+use Mockery as M;
+use PortlandLabs\Community\Discourse\Connect\ConnectController;
+use PortlandLabs\Community\Discourse\Connect\UserTransformer;
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+class ConnectControllerTest extends \PHPUnit\Framework\TestCase
+{
+
+    const PASSWORD = 'testpassword';
+
+    protected static $old;
+
+    /**
+     * @var M\Mock|ResponseFactory
+     */
+    private $factory;
+
+    /**
+     * @var User|M\LegacyMockInterface|M\MockInterface
+     */
+    private $user;
+
+    /**
+     * @var M\LegacyMockInterface|M\MockInterface|UserTransformer
+     */
+    private $transformer;
+
+    /**
+     * @var PostLoginLocation|M\LegacyMockInterface|M\MockInterface
+     */
+    private $postLogin;
+
+    /**
+     * @var ConnectController
+     */
+    private $controller;
+
+    use \Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+
+    public function setUp(): void
+    {
+        $this->factory = M::mock(ResponseFactory::class)->makePartial();
+        $this->user = M::mock(User::class);
+        $this->postLogin = M::mock(PostLoginLocation::class);
+        $this->transformer = M::mock(UserTransformer::class);
+
+        $this->controller = new ConnectController($this->factory, $this->user, $this->postLogin, $this->transformer);
+    }
+
+    public function testUserLoggedIn()
+    {
+        [$payload, $signature] = $this->createPayload(
+            [
+                'nonce' => 'foo_nonce',
+                'return_sso_url' => 'http://example.com',
+            ]
+        );
+
+        // Make a fake request
+        $request = new Request(['sig' => $signature, 'sso' => $payload]);
+
+        // Mark the user as logged in
+        $this->user->shouldReceive('checkLogin')->once()->andReturn(true);
+
+        // Return something from our transformer
+        $this->transformer->shouldReceive('transform')->once()->with($this->user)->andReturn(
+            [
+                'foo' => 'bar'
+            ]
+        );
+
+        // Run the test
+        $result = $this->controller->connect($request);
+
+        $this->assertInstanceOf(\Symfony\Component\HttpFoundation\RedirectResponse::class, $result);
+        $this->assertEquals(302, $result->getStatusCode());
+
+        // Resolve the uri from the redirect response
+        $uri = \League\Url\Url::createFromUrl($result->headers->get('location'));
+        $this->assertEquals('example.com', $uri->getHost());
+
+        $query = $uri->getQuery()->toArray();
+        [$expectedPayload, $expectedSignature,] = $this->createPayload(
+            [
+                'foo' => 'bar',
+                'nonce' => 'foo_nonce',
+            ]
+        );
+
+        $this->assertEquals($expectedSignature, $query['sig'], 'Signature doesn\'t match expected!');
+        $this->assertEquals($expectedPayload, $query['sso'], 'Payload doesn\'t match expected!');
+    }
+
+    public function testUserLoggedOut()
+    {
+        [$payload, $signature] = $this->createPayload(
+            [
+                'nonce' => 'foo_nonce',
+                'return_sso_url' => 'http://example.com',
+            ]
+        );
+
+        // Make a fake request
+        $request = M::mock(Request::class);
+        $request->shouldReceive('get')->andReturnValues([
+            'sso' => $payload,
+            'sig' => $signature
+        ]);
+        $currentUrl = 'http://foo.bar?sig=' . $signature . '&sso=' . $payload;
+        $request->shouldReceive('getUri')->andReturn($currentUrl);
+
+        // Mark the user as not logged in
+        $this->user->shouldReceive('checkLogin')->once()->andReturn(false);
+
+        // Make sure a post login location gets set properly
+        $this->postLogin->shouldReceive('setSessionPostLoginUrl')->once()->with($currentUrl);
+
+        // Run the test
+        $result = $this->controller->connect($request);
+
+        $this->assertInstanceOf(\Symfony\Component\HttpFoundation\RedirectResponse::class, $result);
+        $this->assertEquals(302, $result->getStatusCode());
+        $this->assertEquals('/login', $result->headers->get('location'));
+    }
+
+
+
+    public function testInvalidSignature()
+    {
+        [$payload, $signature] = $this->createPayload(
+            [
+                'nonce' => 'foo_nonce',
+                'return_sso_url' => 'http://example.com',
+            ]
+        );
+
+        $request = new Request(['sig' => 'not valid', 'sso' => $payload]);
+
+        // Make sure we never check if the user is logged in
+        $this->user->shouldNotReceive('checkLogin');
+
+        // Run the test
+        $result = $this->controller->connect($request);
+
+        // Make sure we got the exception we wanted
+        $this->assertInstanceOf(JsonResponse::class, $result);
+        $data = json_decode($result->getContent(), true);
+
+        $this->assertSame(
+            [
+                'success' => false,
+                'error' => [
+                    'code' => 400,
+                    'message' => 'Invalid signature provided.'
+                ]
+            ],
+            $data
+        );
+    }
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$old = getenv('DISCOURSE_SECRET');
+        putenv('DISCOURSE_SECRET=' . self::PASSWORD);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        putenv('DISCOURSE_SECRET=' . self::$old);
+    }
+
+    private function createPayload(array $data)
+    {
+        $string = base64_encode((string) new \League\Url\Components\Query($data));
+        return [$string, hash_hmac('sha256', $string, self::PASSWORD)];
+    }
+
+}


### PR DESCRIPTION
This PR adds support for [DiscourseConnect SSO](https://meta.discourse.org/t/discourseconnect-official-single-sign-on-for-discourse-sso/13045). Some important points:

1. **This is not OAuth2 at all**, instead it's an api endpoint that allows discourse to retrieve information about the *currently logged in concrete5 user*
2. **This endpoint will not output information about any user other than the *currently logged in concrete5 user***. That user is determined like normal using the provided auth cookie

Two typical flows for a user that exists:
1. **User exists, isn't currently logged in to concrete5:**
    1. User navigates to forum
    2. User clicks "Log in", is sent to newly added endpoint from this PR
    3. Endpoint detects no active session, stores *itself* as the post login location and redirects to login page
    4. User logs in, post login location service sends us back to the point we were at in step `1.iii`
    5. Go to `2.iii`
2. **User exists, IS logged in to concrete5:**
    1. User navigates to forum
    2. User clicks "Log in", is sent to newly added endpoint from this PR
    3. Endpoint detects active session, builds payload, builds signature, redirects user back to the forums with payload and signature
    4. User is logged in

