### PR TITLE
Add discourse api protection, make badge boxes always visible, move "edit discourse profile" code

### DIFF
--- a/public/application/config/concrete.php
+++ b/public/application/config/concrete.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'seo' => [
+        'url_rewriting_all' => true
+    ]
+];

--- a/public/packages/concrete_cms_community/blocks/community_badges/templates/achievements_box/view.php
+++ b/public/packages/concrete_cms_community/blocks/community_badges/templates/achievements_box/view.php
@@ -48,73 +48,70 @@ $user = new User();
 ?>
 
 <div class="public-profile" style="margin-top: 0">
-    <?php if (count($badges) > 0) { ?>
-        <div class="card">
-            <div class="card-body">
-                <div class="card-title">
+    <div class="card">
+        <div class="card-body">
+            <div class="card-title" style="margin-bottom: 0;">
                     <span>
                         <?php echo t("Achievements"); ?>
                     </span>
 
-                    <?php if ($isOwnProfile) { ?>
-                        <a href="<?php echo (string)Url::to('/account/karma') ?>"
-                           class="btn btn-sm btn-secondary float-right">
-                            <?php echo t("Earn Achievements"); ?>
-                        </a>
-                    <?php } ?>
-                </div>
+                <?php if ($isOwnProfile) { ?>
+                    <a href="<?php echo (string)Url::to('/account/karma') ?>"
+                       class="btn btn-sm btn-secondary float-right">
+                        <?php echo t("Earn Achievements"); ?>
+                    </a>
+                <?php } ?>
             </div>
+        </div>
 
-            <div class="card-text">
-                <div class="row">
-                    <div class="col">
-                        <?php if (count($badges) > 0) { ?>
-                            <div class="profile-badges">
-                                <?php foreach ($badges as $badge) { ?>
-                                    <div class="profile-badge">
-                                        <?php
-                                        $badgeUrl = $package->getRelativePath() . "/images/default_badge.png";
+        <div class="card-text">
+            <div class="row">
+                <div class="col">
+                    <?php if (count($badges) > 0) { ?>
+                        <div class="profile-badges">
+                            <?php foreach ($badges as $badge) { ?>
+                                <div class="profile-badge">
+                                    <?php
+                                    $badgeUrl = $package->getRelativePath() . "/images/default_badge.png";
 
-                                        $userBadge = $badge["userBadge"];
+                                    $userBadge = $badge["userBadge"];
 
-                                        if ($userBadge instanceof UserBadge) {
-                                            if ($userBadge->getBadge() instanceof Badge) {
-                                                $badgeThumbnail = $userBadge->getBadge()->getThumbnail();
-                                                if ($badgeThumbnail instanceof File) {
-                                                    $badgeThumbnailVersion = $badgeThumbnail->getApprovedVersion();
-                                                    if ($badgeThumbnailVersion instanceof Version) {
-                                                        $badgeUrl = $badgeThumbnailVersion->getURL();
-                                                    }
+                                    if ($userBadge instanceof UserBadge) {
+                                        if ($userBadge->getBadge() instanceof Badge) {
+                                            $badgeThumbnail = $userBadge->getBadge()->getThumbnail();
+                                            if ($badgeThumbnail instanceof File) {
+                                                $badgeThumbnailVersion = $badgeThumbnail->getApprovedVersion();
+                                                if ($badgeThumbnailVersion instanceof Version) {
+                                                    $badgeUrl = $badgeThumbnailVersion->getURL();
                                                 }
                                             }
                                         }
+                                    }
 
-                                        $imageElement = new Image($badgeUrl, $userBadge->getBadge()->getName());
+                                    $imageElement = new Image($badgeUrl, $userBadge->getBadge()->getName());
 
-                                        if ($badge["count"] > 1) {
-                                            $imageWrapper = new Element("div");
-                                            $imageWrapper->addClass("badge-container");
-                                            /** @noinspection PhpParamsInspection */
-                                            $imageWrapper->appendChild($imageElement);
-                                            $imageWrapper->appendChild(new Element("div", $badge["count"], ["class" => "badge-counter", "style" => "margin: 0;"]));
-                                            echo $imageWrapper;
-                                        } else {
-                                            echo $imageElement;
-                                        }
+                                    if ($badge["count"] > 1) {
+                                        $imageWrapper = new Element("div");
+                                        $imageWrapper->addClass("badge-container");
+                                        /** @noinspection PhpParamsInspection */
+                                        $imageWrapper->appendChild($imageElement);
+                                        $imageWrapper->appendChild(new Element("div", $badge["count"], ["class" => "badge-counter", "style" => "margin: 0;"]));
+                                        echo $imageWrapper;
+                                    } else {
+                                        echo $imageElement;
+                                    }
 
-                                        ?>
-                                    </div>
-                                <?php } ?>
-                            </div>
-                        <?php } else { ?>
-                            <div class="none-entered">
-                                <?php echo t("None Entered"); ?>
-                            </div>
-                        <?php } ?>
-                    </div>
+                                    ?>
+                                </div>
+                            <?php } ?>
+                        </div>
+                    <?php } else { ?>
+                        <div class="none-entered text-muted">
+                            <?php echo t("None Entered"); ?>
+                        </div>
+                    <?php } ?>
                 </div>
             </div>
         </div>
-    <?php } ?>
-
+    </div>
 </div>

--- a/public/packages/concrete_cms_community/blocks/community_badges/templates/awards_box/view.php
+++ b/public/packages/concrete_cms_community/blocks/community_badges/templates/awards_box/view.php
@@ -59,10 +59,10 @@ View::getInstance()->addFooterItem(
 ?>
 
 <div class="public-profile" style="margin-top: 0">
-    <?php if ($isOwnProfile && count($grantedAwards) > 0) { ?>
+    <?php if ($isOwnProfile) { ?>
         <div class="card">
             <div class="card-body">
-                <div class="card-title">
+                <div class="card-title" style="margin-bottom: 0;">
                     <span>
                         <?php echo t("Awards"); ?>
                     </span>
@@ -72,6 +72,7 @@ View::getInstance()->addFooterItem(
             <div class="card-text">
                 <div class="row">
                     <div class="col">
+                        <?php if (count($badges) > 0) { ?>
                         <div class="profile-badges">
                             <?php foreach ($grantedAwards as $grantedAward) { ?>
                                 <?php
@@ -156,6 +157,11 @@ View::getInstance()->addFooterItem(
                                 </div>
                             <?php } ?>
                         </div>
+                        <?php } else { ?>
+                            <div class="none-entered text-muted">
+                                <?php echo t("None Entered"); ?>
+                            </div>
+                        <?php } ?>
                     </div>
                 </div>
             </div>

--- a/public/packages/concrete_cms_community/blocks/community_badges/templates/certifications_box/view.php
+++ b/public/packages/concrete_cms_community/blocks/community_badges/templates/certifications_box/view.php
@@ -48,10 +48,9 @@ $user = new User();
 ?>
 
 <div class="public-profile" style="margin-top: 0">
-    <?php if (count($badges) > 0) { ?>
         <div class="card">
             <div class="card-body">
-                <div class="card-title">
+                <div class="card-title" style="margin-bottom: 0;">
                     <span>
                         <?php echo t("Certifications"); ?>
                     </span>
@@ -107,7 +106,7 @@ $user = new User();
                                 <?php } ?>
                             </div>
                         <?php } else { ?>
-                            <div class="none-entered">
+                            <div class="none-entered text-muted">
                                 <?php echo t("None Entered"); ?>
                             </div>
                         <?php } ?>
@@ -115,5 +114,4 @@ $user = new User();
                 </div>
             </div>
         </div>
-    <?php } ?>
 </div>

--- a/public/packages/concrete_cms_community/blocks/forums/view.php
+++ b/public/packages/concrete_cms_community/blocks/forums/view.php
@@ -24,7 +24,7 @@ defined('C5_EXECUTE') or die('Access denied');
                 </span>
 
                 <?php if ($isOwnProfile) { ?>
-                    <a href="<?php echo (string)Url::to(Page::getCurrentPage(), "edit_forum_info"); ?>" target="_blank"
+                    <a href="<?php echo (string)Url::to("/api/v1/discourse/edit_forum_info"); ?>" target="_blank"
                        class="btn btn-sm btn-secondary float-right">
                         <?php echo t("Edit Forum Info"); ?>
                     </a>
@@ -50,7 +50,7 @@ defined('C5_EXECUTE') or die('Access denied');
             <?php } ?>
 
             <?php if ($isOwnProfile) { ?>
-                <?php echo t("Visit your profile in forums %s.", sprintf("<a href=\"%s\" target=\"_blank\">%s</a>", (string)Url::to(Page::getCurrentPage(), "edit_forum_info"), t("here"))) ?>
+                <?php echo t("Visit your profile in forums %s.", sprintf("<a href=\"%s\" target=\"_blank\">%s</a>", (string)Url::to("/api/v1/discourse/edit_forum_info"), t("here"))) ?>
             <?php } ?>
         </div>
     </div>

--- a/public/packages/concrete_cms_community/controller.php
+++ b/public/packages/concrete_cms_community/controller.php
@@ -75,8 +75,8 @@ class Controller extends Package
         $this->installContentFile('data.xml');
         $this->installContentFile('content.xml');
 
-        Page::getByPath('/members/profile')->delete();
-        Single::add('/members/profile', $pkg)->update(['cName' => 'View Profile']);
+        //Page::getByPath('/members/profile')->delete();
+        //Single::add('/members/profile', $pkg)->update(['cName' => 'View Profile']);
 
         $this->configureTeamsFunctionality();
     }

--- a/public/packages/concrete_cms_community/controllers/single_page/dashboard/concrete_cms_community/settings.php
+++ b/public/packages/concrete_cms_community/controllers/single_page/dashboard/concrete_cms_community/settings.php
@@ -63,6 +63,7 @@ class Settings extends DashboardPageController
 
         $this->set('discourseEndpoint', $config->get("concrete_cms_community.discourse.endpoint", ''));
         $this->set('discourseApiKey', $config->get("concrete_cms_community.discourse.api_key", ''));
+        $this->set('discourseSignature', $config->get("concrete_cms_community.discourse.signature", ''));
         $this->set('discourseAchievementsMapping', $config->get("concrete_cms_community.discourse.achievements_mapping", []));
         $this->set('discourseCommunityPointsMapping', $config->get("concrete_cms_community.discourse.community_points_mapping", []));
         $this->set('availableDiscourseEventTypes',$availableDiscourseEventTypes);
@@ -83,6 +84,7 @@ class Settings extends DashboardPageController
 
                 $config->save("concrete_cms_community.discourse.endpoint", (string)$this->request->request->get("discourseEndpoint"));
                 $config->save("concrete_cms_community.discourse.api_key", (string)$this->request->request->get("discourseApiKey"));
+                $config->save("concrete_cms_community.discourse.signature", (string)$this->request->request->get("discourseSignature"));
                 $config->save("concrete_cms_community.discourse.achievements_mapping", $this->request->request->get("discourseAchievementsMapping", []));
                 $config->save("concrete_cms_community.discourse.community_points_mapping", $this->request->request->get("discourseCommunityPointsMapping", []));
 

--- a/public/packages/concrete_cms_community/controllers/single_page/members/profile.php
+++ b/public/packages/concrete_cms_community/controllers/single_page/members/profile.php
@@ -10,88 +10,17 @@
 namespace Concrete\Package\ConcreteCmsCommunity\Controller\SinglePage\Members;
 
 use Concrete\Controller\SinglePage\Members\Profile as CoreProfile;
-use Concrete\Core\Application\EditResponse;
-use Concrete\Core\Config\Repository\Repository;
-use Concrete\Core\Error\ErrorList\ErrorList;
 use Concrete\Core\Http\Request;
 use Concrete\Core\Http\Response;
 use Concrete\Core\Http\ResponseFactory;
 use Concrete\Core\Page\Page;
-use Concrete\Core\Routing\RedirectResponse;
 use Concrete\Core\Support\Facade\Application;
 use Concrete\Core\Support\Facade\Url;
-use Concrete\Core\User\User;
 use Concrete\Core\User\UserInfo;
 use Concrete\Core\User\UserInfoRepository;
-use GuzzleHttp\Client;
-use GuzzleHttp\Exception\GuzzleException;
-use GuzzleHttp\Psr7\Uri;
-use Symfony\Component\HttpFoundation\JsonResponse;
 
 class Profile extends CoreProfile
 {
-    /**
-     * This method redirects the user to the associated discourse edit profile page
-     *
-     * @return RedirectResponse|JsonResponse
-     */
-    public function edit_forum_info()
-    {
-        $currentUser = new User();
-        $app = Application::getFacadeApplication();
-        /** @var Repository $config */
-        $config = $app->make(Repository::class);
-        $errorList = new ErrorList();
-        $discourseEndpoint = $config->get("concrete_cms_community.discourse.endpoint");
-        $discourseApiKey = $config->get("concrete_cms_community.discourse.api_key");
-        $baseUrl = new Uri($discourseEndpoint);
-        $client = new Client();
-        $discourseUsername = "";
-
-        $apiUrl = $baseUrl
-            ->withPath(
-                sprintf(
-                    "/u/by-external/%s.json",
-                    (string)$currentUser->getUserID()
-                )
-            );
-
-        try {
-            $response = $client->request("GET", $apiUrl, [
-                "headers" => [
-                    "Api-Key" => $discourseApiKey
-                ]
-            ]);
-
-            if ($response->getStatusCode() === Response::HTTP_OK) {
-                $rawResponse = $response->getBody()->getContents();
-                $json = json_decode($rawResponse, true);
-
-                if (isset($json["user"]["username"])) {
-                    $discourseUsername = $json["user"]["username"];
-                } else {
-                    $errorList->add(t("Error while looking up the user details. Invalid payload."));
-                }
-            }  else {
-                $errorList->add(t("Error while looking up the user details. Invalid status code."));
-            }
-
-        } catch (GuzzleException $e) {
-            $errorList->add(t("Error while looking up the user details. Internal server error."));
-        }
-
-        if (!$errorList->has()) {
-            $redirectUrl = (string)$baseUrl
-                ->withPath(
-                    sprintf(
-                        "/u/%s/preferences/account",
-                        $discourseUsername
-                    )
-                );
-
-            return new RedirectResponse($redirectUrl, Response::HTTP_TEMPORARY_REDIRECT);
-        }
-    }
 
     /**
      * This method is required for Discourse to display the user profile from the account email address.

--- a/public/packages/concrete_cms_community/controllers/single_page/members/profile.php
+++ b/public/packages/concrete_cms_community/controllers/single_page/members/profile.php
@@ -10,47 +10,11 @@
 namespace Concrete\Package\ConcreteCmsCommunity\Controller\SinglePage\Members;
 
 use Concrete\Controller\SinglePage\Members\Profile as CoreProfile;
-use Concrete\Core\Http\Request;
-use Concrete\Core\Http\Response;
-use Concrete\Core\Http\ResponseFactory;
-use Concrete\Core\Page\Page;
-use Concrete\Core\Support\Facade\Application;
-use Concrete\Core\Support\Facade\Url;
-use Concrete\Core\User\UserInfo;
-use Concrete\Core\User\UserInfoRepository;
 
 class Profile extends CoreProfile
 {
-
-    /**
-     * This method is required for Discourse to display the user profile from the account email address.
-     *
-     * @return bool|Response|\Concrete\Core\Routing\RedirectResponse|mixed|\Symfony\Component\HttpFoundation\Response
-     */
-    public function lookup_email()
-    {
-        $app = Application::getFacadeApplication();
-        /** @var Request $request */
-        $request = $app->make(Request::class);
-        /** @var UserInfoRepository $userInfoRepository */
-        $userInfoRepository = $app->make(UserInfoRepository::class);
-        /** @var ResponseFactory $responseFactory */
-        $responseFactory = $app->make(ResponseFactory::class);
-
-        $email = $request->query->get("email", "");
-
-        $userInfo = $userInfoRepository->getByEmail($email);
-
-        if ($userInfo instanceof UserInfo) {
-            return $responseFactory->redirect((string)Url::to("/members/profile/", $userInfo->getUserID()), Response::HTTP_TEMPORARY_REDIRECT);
-        } else {
-            return $responseFactory->notFound(Page::getCurrentPage());
-        }
-    }
-
     public function on_start()
     {
-
         $this->set('exclude_breadcrumb', true);
 
         return parent::on_start();

--- a/public/packages/concrete_cms_community/single_pages/dashboard/concrete_cms_community/settings.php
+++ b/public/packages/concrete_cms_community/single_pages/dashboard/concrete_cms_community/settings.php
@@ -21,6 +21,7 @@ use Concrete\Core\Validation\CSRF\Token;
 /** @var Concrete\Core\Tree\Tree $tree */
 /** @var string $discourseEndpoint */
 /** @var string $discourseApiKey */
+/** @var string $discourseSignature */
 /** @var array $discourseAchievementsMapping */
 /** @var array $discourseCommunityPointsMapping */
 /** @var array $availableDiscourseEventTypes */
@@ -112,6 +113,11 @@ $token = $app->make(Token::class);
         <div class="form-group">
             <?php echo $form->label("discourseApiKey", t("Api Key")); ?>
             <?php echo $form->password('discourseApiKey', $discourseApiKey); ?>
+        </div>
+
+        <div class="form-group">
+            <?php echo $form->label("discourseSignature", t("Signature")); ?>
+            <?php echo $form->password('discourseSignature', $discourseSignature); ?>
         </div>
     </fieldset>
 

--- a/public/packages/concrete_cms_community/src/API/ServiceProvider.php
+++ b/public/packages/concrete_cms_community/src/API/ServiceProvider.php
@@ -7,6 +7,7 @@ use Concrete\Core\Http\Middleware\OAuthAuthenticationMiddleware;
 use Concrete\Core\Routing\Router;
 use PortlandLabs\Community\API\V1\Achievements;
 use PortlandLabs\Community\API\V1\Middleware\FractalNegotiatorMiddleware;
+use PortlandLabs\Community\API\V1\Profile;
 use PortlandLabs\Community\API\V1\ShowcaseItems;
 use PortlandLabs\Community\API\V1\Teams;
 use PortlandLabs\Community\API\V1\Discourse;
@@ -31,6 +32,7 @@ class ServiceProvider extends Provider
                 $groupRouter->post('/teams/search', [Teams::class, 'search']);
                 $groupRouter->all('/discourse/handle_webhook_event', [Discourse::class, 'handleWebhookEvent']);
                 $groupRouter->all('/discourse/edit_forum_info', [Discourse::class, 'editFormInfo']);
+                $groupRouter->all('/profile/lookup_email', [Profile::class, 'lookupEmail']);
             });
 
         $router->buildGroup()

--- a/public/packages/concrete_cms_community/src/API/ServiceProvider.php
+++ b/public/packages/concrete_cms_community/src/API/ServiceProvider.php
@@ -30,6 +30,7 @@ class ServiceProvider extends Provider
                 $groupRouter->get('/showcase_items/delete', [ShowcaseItems::class, 'delete']);
                 $groupRouter->post('/teams/search', [Teams::class, 'search']);
                 $groupRouter->all('/discourse/handle_webhook_event', [Discourse::class, 'handleWebhookEvent']);
+                $groupRouter->all('/discourse/edit_forum_info', [Discourse::class, 'editFormInfo']);
             });
 
         $router->buildGroup()

--- a/public/packages/concrete_cms_community/src/API/V1/Discourse.php
+++ b/public/packages/concrete_cms_community/src/API/V1/Discourse.php
@@ -82,182 +82,200 @@ class Discourse
             if ($this->config->has("concrete_cms_community.discourse.endpoint")) {
                 $discourseEndpoint = $this->config->get("concrete_cms_community.discourse.endpoint");
 
-                if ($this->config->has("concrete_cms_community.discourse.api_key")) {
-                    $discourseApiKey = $this->config->get("concrete_cms_community.discourse.api_key");
+                if ($this->config->has("concrete_cms_community.discourse.signature")) {
+                    $discourseSignature = $this->config->get("concrete_cms_community.discourse.signature");
 
-                    if ($this->config->has("concrete_cms_community.discourse.achievements_mapping") &&
-                        is_array($this->config->get("concrete_cms_community.discourse.achievements_mapping"))) {
+                    if ($this->config->has("concrete_cms_community.discourse.api_key")) {
+                        $discourseApiKey = $this->config->get("concrete_cms_community.discourse.api_key");
 
-                        $achievementsMapping = $this->config->get("concrete_cms_community.discourse.achievements_mapping");
-                        $communityPointsMapping = $this->config->get("concrete_cms_community.discourse.community_points_mapping");
+                        if ($this->config->has("concrete_cms_community.discourse.achievements_mapping") &&
+                            is_array($this->config->get("concrete_cms_community.discourse.achievements_mapping"))) {
 
-                        if (0 === strpos($this->request->headers->get('Content-Type'), 'application/json')) {
-                            $data = json_decode($this->request->getContent(), true);
+                            $achievementsMapping = $this->config->get("concrete_cms_community.discourse.achievements_mapping");
+                            $communityPointsMapping = $this->config->get("concrete_cms_community.discourse.community_points_mapping");
 
-                            if (is_array($data) || count($data) === 0) {
-                                if ($this->request->headers->has("X-Discourse-Event")) {
-                                    if ($this->request->headers->has("X-Discourse-Event-Type")) {
-                                        $eventName = $this->request->headers->get("X-Discourse-Event");
-                                        $eventType = $this->request->headers->get("X-Discourse-Event-Type");
+                            if (0 === strpos($this->request->headers->get('Content-Type'), 'application/json')) {
+                                $rawResponse = $this->request->getContent();
+                                $data = json_decode($rawResponse, true);
 
-                                        if (isset($data[$eventType])) {
-                                            if (isset($data[$eventType]["external_id"])) {
-                                                /*
-                                                 * Perfect in this payload the external id is given.
-                                                 * No need to use the API to retrieve user details.
-                                                 */
+                                if (is_array($data) || count($data) === 0) {
+                                    if ($this->request->headers->has("X-Discourse-Event")) {
+                                        if ($this->request->headers->has("X-Discourse-Event-Type")) {
+                                            if ($this->request->headers->has("X-Discourse-Event-Signature")) {
+                                                $eventName = $this->request->headers->get("X-Discourse-Event");
+                                                $eventType = $this->request->headers->get("X-Discourse-Event-Type");
+                                                $eventSignature = substr($this->request->headers->get("X-Discourse-Event-Signature"), 7); // 7 because of the leading "sha256="
 
-                                                $userInfo = $this->userInfoRepository->getByID($data[$eventType]["external_id"]);
+                                                $calculatedSignature = hash_hmac('sha256', $rawResponse, $discourseSignature);
 
-                                            } else if (isset($data[$eventType]["user_id"])) {
-                                                $userId = $data[$eventType]["user_id"];
+                                                if ($calculatedSignature === $eventSignature) {
 
-                                                $this->logger->info(t("Event %s raised for discourse user with ID #%s.", $eventName, $userId));
+                                                    if (isset($data[$eventType])) {
+                                                        if (isset($data[$eventType]["external_id"])) {
+                                                            /*
+                                                             * Perfect in this payload the external id is given.
+                                                             * No need to use the API to retrieve user details.
+                                                             */
 
-                                                /*
-                                                 * Resolve mail address through discourse API
-                                                 *
-                                                 * @see https://docs.discourse.org/#tag/Users/paths/~1admin~1users~1{id}.json/get
-                                                 */
+                                                            $userInfo = $this->userInfoRepository->getByID($data[$eventType]["external_id"]);
 
-                                                $path = sprintf("/admin/users/%s.json", $userId);
+                                                        } else if (isset($data[$eventType]["user_id"])) {
+                                                            $userId = $data[$eventType]["user_id"];
 
-                                                $url = new Uri($discourseEndpoint);
+                                                            $this->logger->info(t("Event %s raised for discourse user with ID #%s.", $eventName, $userId));
 
-                                                $url = $url
-                                                    ->withPath($path);
+                                                            /*
+                                                             * Resolve mail address through discourse API
+                                                             *
+                                                             * @see https://docs.discourse.org/#tag/Users/paths/~1admin~1users~1{id}.json/get
+                                                             */
 
-                                                try {
-                                                    $response = $this->client->request("GET", $url, [
-                                                        "headers" => [
-                                                            "Api-Key" => $discourseApiKey
-                                                        ]
-                                                    ]);
+                                                            $path = sprintf("/admin/users/%s.json", $userId);
 
-                                                    if ($response->getStatusCode() === JsonResponse::HTTP_OK) {
-                                                        $rawResponse = $response->getBody()->getContents();
-                                                        $json = json_decode($rawResponse, true);
+                                                            $url = new Uri($discourseEndpoint);
 
-                                                        if (is_array($json) && count($json) > 0) {
+                                                            $url = $url
+                                                                ->withPath($path);
 
-                                                            if (isset($json["single_sign_on_record"]["external_id"])) {
-                                                                /*
-                                                                 * When discourse is running through an SSO there is no mail address
-                                                                 * in the user details.
-                                                                 *
-                                                                 * The only details that available to get the original user account is the property
-                                                                 * single_sign_on_record.external_id
-                                                                 *
-                                                                 * So let's check first if the property is available and if yes we use this property instead
-                                                                 * of the mail address to resolve the concrete user account.
-                                                                 */
+                                                            try {
+                                                                $response = $this->client->request("GET", $url, [
+                                                                    "headers" => [
+                                                                        "Api-Key" => $discourseApiKey
+                                                                    ]
+                                                                ]);
 
-                                                                $userInfo = $this->userInfoRepository->getByID($json["single_sign_on_record"]["external_id"]);
+                                                                if ($response->getStatusCode() === JsonResponse::HTTP_OK) {
+                                                                    $rawResponse = $response->getBody()->getContents();
+                                                                    $json = json_decode($rawResponse, true);
 
-                                                            } else if (isset($json["email"]) && filter_var($json["email"], FILTER_VALIDATE_EMAIL)) {
-                                                                $email = $json["email"];
+                                                                    if (is_array($json) && count($json) > 0) {
 
-                                                                $userInfo = $this->userInfoRepository->getByEmail($email);
-                                                            } else {
-                                                                $errorList->add(t("Error while looking up the user details. The received response doesn't contain not an valid email property or an external id property."));
+                                                                        if (isset($json["single_sign_on_record"]["external_id"])) {
+                                                                            /*
+                                                                             * When discourse is running through an SSO there is no mail address
+                                                                             * in the user details.
+                                                                             *
+                                                                             * The only details that available to get the original user account is the property
+                                                                             * single_sign_on_record.external_id
+                                                                             *
+                                                                             * So let's check first if the property is available and if yes we use this property instead
+                                                                             * of the mail address to resolve the concrete user account.
+                                                                             */
+
+                                                                            $userInfo = $this->userInfoRepository->getByID($json["single_sign_on_record"]["external_id"]);
+
+                                                                        } else if (isset($json["email"]) && filter_var($json["email"], FILTER_VALIDATE_EMAIL)) {
+                                                                            $email = $json["email"];
+
+                                                                            $userInfo = $this->userInfoRepository->getByEmail($email);
+                                                                        } else {
+                                                                            $errorList->add(t("Error while looking up the user details. The received response doesn't contain not an valid email property or an external id property."));
+                                                                        }
+                                                                    } else {
+                                                                        $errorList->add(t("Error while looking up the user details. The received response is empty."));
+                                                                    }
+                                                                } else {
+                                                                    $errorList->add(t("Error while looking up the user details. Invalid status code received."));
+                                                                }
+                                                            } catch (GuzzleException $e) {
+                                                                $errorList->add(t("Error while looking up the user details. Internal server error."));
                                                             }
                                                         } else {
-                                                            $errorList->add(t("Error while looking up the user details. The received response is empty."));
+                                                            $errorList->add(t("User id is missing.", $eventType));
+                                                        }
+
+                                                        if ($userInfo instanceof UserInfo) {
+                                                            $user = $userInfo->getUserObject();
+
+                                                            $event = new DiscourseWebhookCall();
+                                                            $event->setUser($user);
+                                                            $event->setEventName($eventName);
+                                                            $event->setEventType($eventType);
+                                                            $event->setPayload($data);
+                                                            $eventDispatcher->dispatch("on_discourse_webhook_call", $event);
+
+                                                            if (isset($achievementsMapping[$eventName])) {
+                                                                $achievementHandle = $achievementsMapping[$eventName];
+
+                                                                try {
+                                                                    $achievement = $awardService->getBadgeByHandle($achievementHandle);
+                                                                } catch (Exception $e) {
+                                                                    $achievement = null;
+                                                                }
+
+                                                                if (isset($achievement)) {
+                                                                    try {
+                                                                        $awardService->giveBadge($achievement, $user);
+                                                                    } catch (AchievementAlreadyExists $e) {
+                                                                        $errorList->add(t("Error while assign the achievement. The achievement already exists."));
+                                                                    } catch (InvalidBadgeType $e) {
+                                                                        $errorList->add(t("Error while assign the achievement. Invalid badge type."));
+                                                                    } catch (MailTransportError $e) {
+                                                                        $errorList->add(t("Error while assign the achievement. Mail transport error."));
+                                                                    } catch (NoUserSelected $e) {
+                                                                        $errorList->add(t("Error while assign the achievement. Invalid user."));
+                                                                    }
+                                                                } else {
+                                                                    $errorList->add(t("The achievement with the handle %s does not exists.", $achievementHandle));
+                                                                }
+                                                            }
+
+                                                            if (isset($communityPointsMapping[$eventName])) {
+                                                                $communityPoints = (int)$communityPointsMapping[$eventName];
+
+                                                                if ($communityPoints > 0) {
+                                                                    $userPointAction = UserPointAction::getByHandle("discourse_action");
+
+                                                                    if (!$userPointAction instanceof UserPointAction) {
+                                                                        UserPointAction::add(
+                                                                            "discourse_action",
+                                                                            t("Discourse Action"),
+                                                                            50,
+                                                                            null
+                                                                        );
+
+                                                                        $userPointAction = UserPointAction::getByHandle("discourse_action");
+                                                                    }
+
+                                                                    $userPointActionDescription = new UserPointActionDescription();
+                                                                    $userPointActionDescription->setComments(t("Action: %s", $eventName));
+
+                                                                    $userPointAction->addEntry($user, $userPointActionDescription, $communityPoints);
+                                                                }
+                                                            }
+                                                        } else {
+                                                            $errorList->add(t("The received mail address from the discourse api is not associated with an user account at this site."));
                                                         }
                                                     } else {
-                                                        $errorList->add(t("Error while looking up the user details. Invalid status code received."));
+                                                        $errorList->add(t("Item %s is missing in payload.", $eventType));
                                                     }
-                                                } catch (GuzzleException $e) {
-                                                    $errorList->add(t("Error while looking up the user details. Internal server error."));
+                                                } else {
+                                                    $errorList->add(t("The signature is invalid."));
                                                 }
                                             } else {
-                                                $errorList->add(t("User id is missing.", $eventType));
-                                            }
-
-                                            if ($userInfo instanceof UserInfo) {
-                                                $user = $userInfo->getUserObject();
-
-                                                $event = new DiscourseWebhookCall();
-                                                $event->setUser($user);
-                                                $event->setEventName($eventName);
-                                                $event->setEventType($eventType);
-                                                $event->setPayload($data);
-                                                $eventDispatcher->dispatch("on_discourse_webhook_call", $event);
-
-                                                if (isset($achievementsMapping[$eventName])) {
-                                                    $achievementHandle = $achievementsMapping[$eventName];
-
-                                                    try {
-                                                        $achievement = $awardService->getBadgeByHandle($achievementHandle);
-                                                    } catch (Exception $e) {
-                                                        $achievement = null;
-                                                    }
-
-                                                    if (isset($achievement)) {
-                                                        try {
-                                                            $awardService->giveBadge($achievement, $user);
-                                                        } catch (AchievementAlreadyExists $e) {
-                                                            $errorList->add(t("Error while assign the achievement. The achievement already exists."));
-                                                        } catch (InvalidBadgeType $e) {
-                                                            $errorList->add(t("Error while assign the achievement. Invalid badge type."));
-                                                        } catch (MailTransportError $e) {
-                                                            $errorList->add(t("Error while assign the achievement. Mail transport error."));
-                                                        } catch (NoUserSelected $e) {
-                                                            $errorList->add(t("Error while assign the achievement. Invalid user."));
-                                                        }
-                                                    } else {
-                                                        $errorList->add(t("The achievement with the handle %s does not exists.", $achievementHandle));
-                                                    }
-                                                }
-
-                                                if (isset($communityPointsMapping[$eventName])) {
-                                                    $communityPoints = (int)$communityPointsMapping[$eventName];
-
-                                                    if ($communityPoints > 0) {
-                                                        $userPointAction = UserPointAction::getByHandle("discourse_action");
-
-                                                        if (!$userPointAction instanceof UserPointAction) {
-                                                            UserPointAction::add(
-                                                                "discourse_action",
-                                                                t("Discourse Action"),
-                                                                50,
-                                                                null
-                                                            );
-
-                                                            $userPointAction = UserPointAction::getByHandle("discourse_action");
-                                                        }
-
-                                                        $userPointActionDescription = new UserPointActionDescription();
-                                                        $userPointActionDescription->setComments(t("Action: %s", $eventName));
-
-                                                        $userPointAction->addEntry($user, $userPointActionDescription, $communityPoints);
-                                                    }
-                                                }
-                                            } else {
-                                                $errorList->add(t("The received mail address from the discourse api is not associated with an user account at this site."));
+                                                $errorList->add(t("Header X-Discourse-Event-Signature is missing."));
                                             }
                                         } else {
-                                            $errorList->add(t("Item %s is missing in payload.", $eventType));
+                                            $errorList->add(t("Header X-Discourse-Event-Type is missing."));
                                         }
-
                                     } else {
-                                        $errorList->add(t("Header X-Discourse-Event-Type is missing."));
+                                        $errorList->add(t("Header X-Discourse-Event is missing."));
                                     }
                                 } else {
-                                    $errorList->add(t("Header X-Discourse-Event is missing."));
+                                    $errorList->add(t("Payload is empty."));
                                 }
                             } else {
-                                $errorList->add(t("Payload is empty."));
+                                $errorList->add(t("Content type is invalid."));
                             }
                         } else {
-                            $errorList->add(t("Content type is invalid."));
+                            $errorList->add(t("There are no achievements mapped with the discourse events."));
                         }
-                    } else {
-                        $errorList->add(t("There are no achievements mapped with the discourse events."));
-                    }
 
+                    } else {
+                        $errorList->add(t("You need to define an api key for the discourse integration."));
+                    }
                 } else {
-                    $errorList->add(t("You need to define an api key for the discourse integration."));
+                    $errorList->add(t("You need to define a signature for the discourse integration."));
                 }
             } else {
                 $errorList->add(t("You need to define an endpoint for the discourse integration."));

--- a/public/packages/concrete_cms_community/src/API/V1/Profile.php
+++ b/public/packages/concrete_cms_community/src/API/V1/Profile.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * @project:   ConcreteCMS Community
+ *
+ * @copyright  (C) 2021 Portland Labs (https://www.portlandlabs.com)
+ * @author     Fabian Bitter (fabian@bitter.de)
+ */
+
+namespace PortlandLabs\Community\API\V1;
+
+use Concrete\Core\Http\Request;
+use Concrete\Core\Http\Response;
+use Concrete\Core\Http\ResponseFactory;
+use Concrete\Core\Page\Page;
+use Concrete\Core\Support\Facade\Application;
+use Concrete\Core\Support\Facade\Url;
+use Concrete\Core\User\UserInfo;
+use Concrete\Core\User\UserInfoRepository;
+
+class Profile
+{
+
+    /**
+     * @return bool|Response|\Concrete\Core\Routing\RedirectResponse|mixed|\Symfony\Component\HttpFoundation\Response
+     */
+    public function lookupEmail()
+    {
+        $app = Application::getFacadeApplication();
+        /** @var Request $request */
+        $request = $app->make(Request::class);
+        /** @var UserInfoRepository $userInfoRepository */
+        $userInfoRepository = $app->make(UserInfoRepository::class);
+        /** @var ResponseFactory $responseFactory */
+        $responseFactory = $app->make(ResponseFactory::class);
+
+        $email = $request->query->get("email", "");
+
+        $userInfo = $userInfoRepository->getByEmail($email);
+
+        if ($userInfo instanceof UserInfo) {
+            return $responseFactory->redirect((string)Url::to("/members/profile/", $userInfo->getUserID()), Response::HTTP_TEMPORARY_REDIRECT);
+        } else {
+            return $responseFactory->notFound(Page::getCurrentPage());
+        }
+    }
+}


### PR DESCRIPTION
- Add sha256 signature check to the discourse api integration
- Make badge boxes visible also when non available + update design.
- Move code for the edit discourse profile redirect to an api method. Can't use the block controller or page controller because all action_ methods ignored by the core.
